### PR TITLE
Fix daemon freeze

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.13.1-beta
+  version: 0.13.2-beta
 repo:
   repo:
     host: github.com

--- a/cli/as_cli.cc
+++ b/cli/as_cli.cc
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
 
     grpc::Status status = stub->Kill(&context, request, &response);
 
-    if (!status.ok()) {
+    if (!status.ok() && status.error_message() != "Socket closed") {
       cout << "kill failed: " << status.error_message() << endl;
       return 0;
     }

--- a/daemon/global.cc
+++ b/daemon/global.cc
@@ -21,8 +21,6 @@ auto Global::wait_for_transmitter_ping_with_timeout(int seconds) -> bool {
 
   auto did_get_pinged = transmitter_ping_counter != counter_start;
 
-  l.unlock();
-
   return did_get_pinged;
 }
 
@@ -45,8 +43,6 @@ auto Global::wait_for_grpc_ping_with_timeout(int seconds) -> bool {
       [this, counter_start] { return grpc_ping_counter != counter_start; });
 
   auto did_get_pinged = grpc_ping_counter != counter_start;
-
-  l.unlock();
 
   return did_get_pinged;
 }

--- a/daemon/global.hpp
+++ b/daemon/global.hpp
@@ -27,6 +27,10 @@ class Global {
   // returns true if the transmitter did ping, false otherwise
   auto wait_for_transmitter_ping_with_timeout(int seconds) -> bool;
 
+  auto grpc_ping() -> void;
+  // returns true if the grpc did ping, false otherwise
+  auto wait_for_grpc_ping_with_timeout(int seconds) -> bool;
+
   const string db_address;
   const rust::Box<db::DB> db;
 
@@ -39,4 +43,8 @@ class Global {
   std::mutex transmitter_ping_mtx;
   std::condition_variable transmitter_ping_cv;
   int transmitter_ping_counter = 0;
+
+  std::mutex grpc_ping_mtx;
+  std::condition_variable grpc_ping_cv;
+  int grpc_ping_counter = 0;
 };

--- a/daemon/global.hpp
+++ b/daemon/global.hpp
@@ -20,13 +20,17 @@ class Global {
   Global(Global&& other) noexcept = delete;
   Global& operator=(const Global& other) = delete;
   Global& operator=(Global&& other) noexcept = delete;
-
+ 
+  // The transmitter check_rep() calls alive() to check that the
+  // Global is consistent and working.  
   auto alive() const noexcept -> bool { return true; }
 
+  // The transmitter calls this to signal that it is alive.
   auto transmitter_ping() -> void;
   // returns true if the transmitter did ping, false otherwise
   auto wait_for_transmitter_ping_with_timeout(int seconds) -> bool;
 
+  // The GRPC thread calls this to signal that it is alive
   auto grpc_ping() -> void;
   // returns true if the grpc did ping, false otherwise
   auto wait_for_grpc_ping_with_timeout(int seconds) -> bool;

--- a/daemon/global.hpp
+++ b/daemon/global.hpp
@@ -21,11 +21,11 @@ class Global {
   Global& operator=(const Global& other) = delete;
   Global& operator=(Global&& other) noexcept = delete;
 
-  auto alive() const noexcept -> bool { return !kill_; }
+  auto alive() const noexcept -> bool { return true; }
 
-  auto kill() -> void;
-  // returns true iff killed
-  auto wait_until_killed_or_seconds(int seconds) -> bool;
+  auto transmitter_ping() -> void;
+  // returns true if the transmitter did ping, false otherwise
+  auto wait_for_transmitter_ping_with_timeout(int seconds) -> bool;
 
   const string db_address;
   const rust::Box<db::DB> db;
@@ -36,7 +36,7 @@ class Global {
   std::condition_variable message_notification_cv;
 
  private:
-  std::mutex kill_mtx;
-  std::condition_variable kill_cv;
-  bool kill_ = false;
+  std::mutex transmitter_ping_mtx;
+  std::condition_variable transmitter_ping_cv;
+  int transmitter_ping_counter = 0;
 };

--- a/daemon/main.cc
+++ b/daemon/main.cc
@@ -50,7 +50,7 @@ auto main_cc_impl(rust::Vec<rust::String> args) -> void {
       cout << "  -r <round_delay>  Round delay in seconds (default: 60 seconds)"
            << endl;
       cout << "  --no-tls  Don't use TLS (default: use tls)" << endl;
-      return 0;
+      return;
     } else if (*i == "-s") {
       server_address = *++i;
     } else if (*i == "-d") {
@@ -63,7 +63,7 @@ auto main_cc_impl(rust::Vec<rust::String> args) -> void {
       tls = false;
     } else {
       ASPHR_LOG_ERR("Unknown argument.", argument, *i);
-      return 1;
+      throw std::invalid_argument("Unknown argument.");
     }
   }
 
@@ -149,8 +149,7 @@ auto main_cc(rust::Vec<rust::String> args) -> void {
     ASPHR_LOG_ERR(
         "Main function returned, which means there's an error somewhere.");
   } catch (const std::exception& e) {
-    ASPHR_LOG_ERR("Main failing fatally :(, probably with a database error.",
-                  exception, e.what());
+    ASPHR_LOG_ERR("Main failing fatally :(.", exception, e.what());
   } catch (...) {
     ASPHR_LOG_ERR("Main failing fatally :(.", exception, "unknown");
   }

--- a/daemon/main.cc
+++ b/daemon/main.cc
@@ -19,7 +19,7 @@ auto get_db_address() noexcept(false) -> std::filesystem::path {
   return get_daemon_config_dir() / "asphr.db";
 }
 
-int main_cc_impl(rust::Vec<rust::String> args) {
+auto main_cc_impl(rust::Vec<rust::String> args) -> void {
   vector<string> args_vec;
   for (auto i = args.begin() + 1; i != args.end(); ++i) {
     args_vec.push_back(std::string(*i));
@@ -141,13 +141,11 @@ int main_cc_impl(rust::Vec<rust::String> args) {
       G.wait_until_killed_or_seconds(30);
     }
   }
-
-  return 0;
 }
 
-int main_cc(rust::Vec<rust::String> args) {
+auto main_cc(rust::Vec<rust::String> args) -> void {
   try {
-    return main_cc_impl(args);
+    main_cc_impl(args);
   } catch (const std::exception& e) {
     ASPHR_LOG_ERR("Main failing fatally :(, probably with a database error.",
                   exception, e.what());

--- a/daemon/main.cc
+++ b/daemon/main.cc
@@ -146,9 +146,14 @@ auto main_cc_impl(rust::Vec<rust::String> args) -> void {
 auto main_cc(rust::Vec<rust::String> args) -> void {
   try {
     main_cc_impl(args);
+    ASPHR_LOG_ERR(
+        "Main function returned, which means there's an error somewhere.");
   } catch (const std::exception& e) {
     ASPHR_LOG_ERR("Main failing fatally :(, probably with a database error.",
                   exception, e.what());
-    throw;
+  } catch (...) {
+    ASPHR_LOG_ERR("Main failing fatally :(.", exception, "unknown");
   }
+  // the main function should never return! it might be getting killed.
+  std::exit(1);
 }

--- a/daemon/main.cc
+++ b/daemon/main.cc
@@ -50,7 +50,7 @@ auto main_cc_impl(rust::Vec<rust::String> args) -> void {
       cout << "  -r <round_delay>  Round delay in seconds (default: 60 seconds)"
            << endl;
       cout << "  --no-tls  Don't use TLS (default: use tls)" << endl;
-      return;
+      std::exit(0);
     } else if (*i == "-s") {
       server_address = *++i;
     } else if (*i == "-d") {

--- a/daemon/main.hpp
+++ b/daemon/main.hpp
@@ -2,4 +2,7 @@
 
 #include "rust/cxx.h"
 
-int main_cc(rust::Vec<rust::String> args);
+// no return code. instead, to exit with a return code, explicitly call
+// exit(code). if this function returns normally, the process will be exited
+// with status code 0.
+auto main_cc(rust::Vec<rust::String> args) -> void;

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -6,12 +6,14 @@ fn main() {
 
   let result = cli::cli(args);
   ffi::main_cc(result);
+  // we can never get here. main_cc will always exit the process.
+  panic!("main_cc should never return");
 }
 
 #[cxx::bridge]
 mod ffi {
   unsafe extern "C++" {
     include!("daemon/main.hpp");
-    fn main_cc(args: Vec<String>) -> i32;
+    fn main_cc(args: Vec<String>);
   }
 }

--- a/daemon/rpc/daemon_rpc.cc
+++ b/daemon/rpc/daemon_rpc.cc
@@ -663,6 +663,8 @@ auto DaemonRpc::Kill(ServerContext* context,
   ASPHR_LOG_INFO("Daemon is shutting down.", rpc_call, "Kill");
   // exit normally! being killed is not a bad thing.
   // the daemon manager will restart us which is great :)
+  //
+  // the OS will clean up after us, so we don't need to worry
   std::exit(0);
   return Status::OK;
 }

--- a/daemon/rpc/daemon_rpc.cc
+++ b/daemon/rpc/daemon_rpc.cc
@@ -660,7 +660,9 @@ auto DaemonRpc::Kill(ServerContext* context,
                      const asphrdaemon::KillRequest* killRequest,
                      asphrdaemon::KillResponse* killResponse) -> Status {
   ASPHR_LOG_INFO("Kill() called.", rpc_call, "Kill");
-  G.kill();
-  ASPHR_LOG_INFO("Daemon is shutting down asap.", rpc_call, "Kill");
+  ASPHR_LOG_INFO("Daemon is shutting down.", rpc_call, "Kill");
+  // exit normally! being killed is not a bad thing.
+  // the daemon manager will restart us which is great :)
+  std::exit(0);
   return Status::OK;
 }

--- a/daemon/rpc/daemon_rpc.cc
+++ b/daemon/rpc/daemon_rpc.cc
@@ -35,6 +35,8 @@ Status DaemonRpc::RegisterUser(
 
   asphrserver::RegisterResponse reply;
   grpc::ClientContext client_context;
+  client_context.set_deadline(std::chrono::system_clock::now() +
+                              std::chrono::seconds(60));
 
   Status status = stub->Register(&client_context, request, &reply);
 

--- a/daemon/rpc/daemon_rpc.cc
+++ b/daemon/rpc/daemon_rpc.cc
@@ -665,6 +665,7 @@ auto DaemonRpc::Kill(ServerContext* context,
   // the daemon manager will restart us which is great :)
   //
   // the OS will clean up after us, so we don't need to worry
+  ASPHR_LOG_ERR("Exiting.", status_code, 0);
   std::exit(0);
   return Status::OK;
 }

--- a/daemon/transmitter/transmitter.cc
+++ b/daemon/transmitter/transmitter.cc
@@ -400,6 +400,8 @@ auto Transmitter::send() -> void {
   asphrserver::SendMessageResponse reply;
 
   grpc::ClientContext context;
+  context.set_deadline(std::chrono::system_clock::now() +
+                       std::chrono::seconds(60));
 
   grpc::Status status = stub->SendMessage(&context, request, &reply);
 
@@ -435,6 +437,8 @@ auto Transmitter::batch_retrieve_pir(FastPIRClient& client,
 
     asphrserver::ReceiveMessageResponse reply;
     grpc::ClientContext context;
+    context.set_deadline(std::chrono::system_clock::now() +
+                         std::chrono::seconds(60));
 
     grpc::Status status = stub->ReceiveMessage(&context, request, &reply);
 


### PR DESCRIPTION
Fixes daemon freeze by adding a deadline to all gRPC calls.

Also makes the main thread monitor the health of both the gRPC server and the transmitter, which is now in its own thread. Every 10 minutes or so, the main thread will check that both the gRPC server and the transmitter is alive. If either of them are not, it will exit the process with a status code of 1. This will allow the daemon manager to restart the process and hopefully fix the problem.